### PR TITLE
Clearing the metric at each iteration to ensure that we don't have old labels being reported

### DIFF
--- a/cexporter/cmmc_vdi_code_version.py
+++ b/cexporter/cmmc_vdi_code_version.py
@@ -11,9 +11,11 @@ def collect_cmmc_version():
         response = requests.get(url, headers=headers)
         response.raise_for_status()  # Raise an exception for HTTP errors
         version = response.text.strip()
+        cmmc_vdi_version.clear()
         cmmc_vdi_version.labels(version=version).set(1)
     except requests.exceptions.RequestException as e:
         print(f"Error fetching cmmc vdi code version: {e}")
         version = "unknown"
+        cmmc_vdi_version.clear()
         cmmc_vdi_version.labels(version=version).set(0)
     return cmmc_vdi_version


### PR DESCRIPTION
Without this, when the version would change, it would be reported as a metric, but the old version would still get reported to Prometheus, as it was a metric with a different label. This will make sure we only report one version at a time.